### PR TITLE
Automated deployment

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -54,9 +54,9 @@ namespace :deploy do
   def trigger_deployment(application, build, branch)
     url = "https://circleci.com/api/v1/project/ad2games/deployment/tree/master?circle-token=#{ENV['CIRCLE_TOKEN']}"
     build_params = {
-      application: application,
-      build: build,
-      environment: branch == 'master' ? 'production' : branch
+      DEPLOYMENT_APP: application,
+      DEPLOYMENT_BUILD: build,
+      DEPLOYMENT_ENV: branch == 'master' ? 'production' : branch
     }
     HTTParty.post url, body: build_params.to_json, headers: { 'Content-Type' => 'application/json' }
   end

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -54,10 +54,15 @@ namespace :deploy do
   def trigger_deployment(application, build, branch)
     url = "https://circleci.com/api/v1/project/ad2games/deployment/tree/master?circle-token=#{ENV['CIRCLE_TOKEN']}"
     build_params = {
+      AUTO_DEPLOYMENT: '1',
       DEPLOYMENT_APP: application,
       DEPLOYMENT_BUILD: build,
       DEPLOYMENT_ENV: branch == 'master' ? 'production' : branch
     }
-    HTTParty.post url, body: build_params.to_json, headers: { 'Content-Type' => 'application/json' }
+    response = HTTParty.post url,
+      body: { build_parameters: build_params }.to_json,
+      headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
+    puts "Deployment build triggered with build params: #{response['build_parameters']}"
+    puts "Build URL: #{response['build_url']}"
   end
 end

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -47,5 +47,17 @@ namespace :deploy do
     sh "docker pull #{base_tag}"
     sh "docker build -t #{tag} ."
     sh "docker push #{tag}"
+
+    trigger_deployment(application, build, branch) if branch == 'staging'
+  end
+
+  def trigger_deployment(application, build, branch)
+    url = "https://circleci.com/api/v1/project/ad2games/deployment/tree/master?circle-token=#{ENV['CIRCLE_TOKEN']}"
+    build_params = {
+      application: application,
+      build: build,
+      environment: branch == 'master' ? 'production' : branch
+    }
+    HTTParty.post url, body: build_params.to_json, headers: { 'Content-Type' => 'application/json' }
   end
 end


### PR DESCRIPTION
Trigger a build of the `deployment` repository in CircleCI with build parameters that specify what to deploy.

See also the changes to the `deployment` repo here:
https://github.com/ad2games/deployment/compare/ecf956...e0094b

For now, we only trigger a deployment build for the `staging` branch.
