### PR TITLE
Moves deployment trigger to separate rake task

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -48,6 +48,14 @@ namespace :deploy do
     sh "docker pull #{base_tag}"
     sh "docker build -t #{tag} ."
     sh "docker push #{tag}"
+  end
+
+  desc 'triggers deployment builds on CircleCI'
+  task trigger: [:environment] do
+    branch = ENV.fetch('CIRCLE_BRANCH')
+    build  = ENV.fetch('CIRCLE_BUILD_NUM')
+
+    next unless branch == 'staging'
 
     deploy_apps.uniq.each do |app|
       deploy_envs.fetch(branch, []).each { |env| trigger_deployment(app, build, env) }


### PR DESCRIPTION
This change facilitates additional flexibility when configuring the deployment apps and environments.

In one case in particular, we have two apps deployed from the same codebase with different sets of environments. By separating triggering deployment from building the container, we can call the trigger task multiple times with different configuration options.

Requires some adjustment to existing calls. A call like this:

``` bash
rake deploy:docker DEPLOY_APPS=app1,app2 DEPLOY_ENVS=staging:staging,staging:preview
```

Would now be 2 calls:

``` bash
rake deploy:docker
rake deploy:trigger DEPLOY_APPS=app1,app2 DEPLOY_ENVS=staging:staging,staging:preview
```

Or optionally 3:

``` bash
rake deploy:docker
rake deploy:trigger DEPLOY_APPS=app1 DEPLOY_ENVS=staging:staging,staging:preview
rake deploy:trigger DEPLOY_APPS=app2 DEPLOY_ENVS=staging:staging
```
