### PR TITLE
Remove mention of rails_12factor from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ gem 'docker-deploy', require: false, git: 'https://github.com/ad2games/docker-de
 
 ## What It Does
 - Runs [bundler-audit](https://github.com/rubysec/bundler-audit)
-- Checks that `puma`, `rails_12factor` and `rails_migrate_mutex` are installed
+- Checks that `puma` and `rails_migrate_mutex` are installed
 - Creates a Dockerfile using our [Docker-Rails Baseimage](https://github.com/ad2games/docker-rails)
 - Downloads GeoIP Database (only when `GEOIP_LICENSE_KEY` ENV is set)
 - Pushes container to private Docker Hub repository tagged with the CI build number


### PR DESCRIPTION
We don't check for that anymore.
See commit 116a23c070ee18608676c4d35317cbb1118eb1a9