### PR TITLE
Make touch work with invalid symbolic links

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -39,7 +39,7 @@ namespace :deploy do
     sh "cp -r #{template_dir}/.??* ."
     sh "cp -r #{template_dir}/* ."
     sh "#{scripts_dir}/update_geoip.sh"
-    sh "find . -print0 |xargs -0 touch -t 1111111111"
+    sh "find . -print0 |xargs -0 touch -h -t 1111111111"
     sh "docker login -u #{DEPLOY_USER} -p $DOCKER_PASSWORD"
 
     sh "docker pull #{prev_tag} || true" if prev_build


### PR DESCRIPTION
This fix the build error

touch: cannot touch ‘./vendor/bundle/ruby/2.4.0/gems/database_cleaner-1.6.2/examples/Gemfile’: No such file or directory

Caused by invalid symlink