### PR TITLE
Customize `docker login` command.

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -1,6 +1,7 @@
 GITHUB_ORG = 'ad2games'
 BASE_IMAGE = 'docker-rails:latest'
 DEPLOY_USER = 'ad2gamesdeploy'
+DEPLOY_EMAIL = 'developers@ad2games.com'
 DEPLOY_ENVS = {} # No deployments triggered by default (override DEPLOY_ENVS)
 
 namespace :deploy do
@@ -40,7 +41,13 @@ namespace :deploy do
     sh "cp -r #{template_dir}/* ."
     sh "#{scripts_dir}/update_geoip.sh"
     sh "find . -print0 |xargs -0 touch -h -t 1111111111"
-    sh "docker login -u #{DEPLOY_USER} -p $DOCKER_PASSWORD"
+
+    # check which version version of docker (and its login command) we're dealing with
+    if `docker login --help`.include?('-e, --email')
+      sh "docker login -e #{DEPLOY_EMAIL} -u #{DEPLOY_USER} -p $DOCKER_PASSWORD"
+    else
+      sh "docker login -u #{DEPLOY_USER} -p $DOCKER_PASSWORD"
+    end
 
     sh "docker pull #{prev_tag} || true" if prev_build
     sh "docker pull #{base_tag}"


### PR DESCRIPTION
Old versions of docker login require an email parameter where newer
versions don't. This PR should fix the docker-deploy build for all
projects using circleci-1.0 while still keeping it working for all
projects that are using circleci-2.0.