### PR TITLE
Add support for different ruby versions.

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,1 +1,0 @@
-FROM ad2games/docker-rails:latest

--- a/config/Dockerfile.erb
+++ b/config/Dockerfile.erb
@@ -1,0 +1,1 @@
+FROM <%= base_tag %>


### PR DESCRIPTION
After applying this patch docker-deploy will look into the .ruby-version file of the project to figure out which docker-rails image to pull rather than always using latest.

I'll plan on merging when https://github.com/ad2games/docker-rails/pull/20 is ready.