### PR TITLE
Revert "Allow to use insecure rubyzip gem version"

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -8,8 +8,7 @@ namespace :deploy do
     require 'bundler/audit/cli'
 
     Bundler::Audit::CLI.start(['update'])
-    # Remove the ignore option once https://github.com/rubyzip/rubyzip/issues/369 is fixed
-    Bundler::Audit::CLI.start(['-i=CVE-2018-1000544', 'check'])
+    Bundler::Audit::CLI.start(['check'])
   end
 
   def base_image


### PR DESCRIPTION
This reverts commit cc7080d8765d0795daecd0107b1ca1eb15433fa5.

As rubyzip 1.2.2 has been released