### PR TITLE
Pass along BUGSNAG_API_KEY and CIRCLE_BUILD_NUM

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -87,8 +87,8 @@ namespace :deploy do
     sh "docker pull #{base_tag}"
     sh <<-SH
       docker build \
-        --build-arg BUGSNAG_API_KEY=#{ENV.fetch('BUGSNAG_API_KEY')} \
-        --build-arg CIRCLE_BUILD_NUM=#{ENV.fetch('CIRCLE_BUILD_NUM')} \
+        --build-arg BUGSNAG_API_KEY \
+        --build-arg CIRCLE_BUILD_NUM \
         -t #{docker_new_image_tag} \
         .
     SH

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -85,7 +85,13 @@ namespace :deploy do
 
     docker_login
     sh "docker pull #{base_tag}"
-    sh "docker build -t #{docker_new_image_tag} ."
+    sh <<-SH
+      docker build \
+        --build-arg BUGSNAG_API_KEY=#{ENV.fetch('BUGSNAG_API_KEY')} \
+        --build-arg CIRCLE_BUILD_NUM=#{ENV.fetch('CIRCLE_BUILD_NUM')} \
+        -t #{docker_new_image_tag} \
+        .
+    SH
   end
 
   def push_image

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -88,7 +88,7 @@ namespace :deploy do
     sh <<-SH
       docker build \
         --build-arg BUGSNAG_API_KEY \
-        --build-arg CIRCLE_BUILD_NUM \
+        --build-arg BUGSNAG_APP_VERSION \
         -t #{docker_new_image_tag} \
         .
     SH


### PR DESCRIPTION
So we can use them when uploading JS source maps to Bugsnag.
See [Bugsnag docs](https://docs.bugsnag.com/build-integrations/webpack/#uploading-source-maps).