### PR TITLE
Remove .bundle/ and vendor/cache from .dockerignore

### DIFF
--- a/config/.dockerignore
+++ b/config/.dockerignore
@@ -1,3 +1,4 @@
+.bundle/
 .git/
 client/
 coverage/

--- a/config/.dockerignore
+++ b/config/.dockerignore
@@ -7,5 +7,4 @@ tmp/
 vendor/assets/.bowerrc
 vendor/assets/bower.json
 vendor/assets/bower_components/
-vendor/cache/
 vendor/bundle/

--- a/config/.dockerignore
+++ b/config/.dockerignore
@@ -1,4 +1,3 @@
-.bundle/
 .git/
 client/
 coverage/

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -89,6 +89,7 @@ namespace :deploy do
       docker build \
         --build-arg BUGSNAG_API_KEY \
         --build-arg BUGSNAG_APP_VERSION \
+        --build-arg BUNDLE_LOCAL \
         -t #{docker_new_image_tag} \
         .
     SH

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -89,7 +89,6 @@ namespace :deploy do
       docker build \
         --build-arg BUGSNAG_API_KEY \
         --build-arg BUGSNAG_APP_VERSION \
-        --build-arg BUNDLE_LOCAL \
         -t #{docker_new_image_tag} \
         .
     SH


### PR DESCRIPTION
In order to be able to use `bundle package` to add all gems to the Docker image, we need to keep `.bundle/config`, so `bundle install --deployment` knows, that it shouldn't fetch the dependencies but use the cached gems, as well as `vendor/cache` for obvious reasons.

Related docs: https://bundler.io/v1.17/bundle_install.html (see at the bottom, the part about the `--deployment` flag)